### PR TITLE
[nasa/nos3#163] Spacecraft Docker 

### DIFF
--- a/fsw/nos-linux/src/cfe_psp_start.c
+++ b/fsw/nos-linux/src/cfe_psp_start.c
@@ -83,7 +83,7 @@
 #define CFE_PSP_RESET_NAME_LENGTH 10
 
 /* Constants used for NOS Engine Time and NOS Engine bus */
-#define ENGINE_SERVER_URI       "tcp://127.0.0.1:12000"
+#define ENGINE_SERVER_URI       "tcp://nos_engine_server:12000"
 #define ENGINE_BUS_NAME         "command"
 #define TICKS_PER_SECOND        100
 NE_Bus          *CFE_PSP_Bus;


### PR DESCRIPTION
Updated nos-linux PSP to use the `nos_engine_server` hostname instead of localhost.